### PR TITLE
30_受講生情報削除処理の実装の課題提出（修正）

### DIFF
--- a/src/main/java/raisetech/StudentManagement/Repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/Repository/StudentRepository.java
@@ -9,19 +9,19 @@ import java.util.List;
 
 @Mapper
 public interface StudentRepository {
-    @Select("SELECT * FROM students")
-    List<Student> studentListSearch();
+    @Select("SELECT * FROM students WHERE is_deleted = false ")
+    List<Student> searchStudentList();
 
     @Select("SELECT * FROM students WHERE id = #{id}")
     Student searchStudent(String id);
 
     @Select("SELECT * FROM students_courses")
-    List<StudentCourses> studentCourseListSearch();
+    List<StudentCourses> searchStudentCourseList();
 
     @Select("SELECT * FROM students_courses WHERE student_id = #{student_id}")
     List<StudentCourses> searchStudentCourse(String studentId);
 
-    //Repositoryでデータの保存
+    //Repositoryでデータの保存、受講生情報更新処理
     @Insert("INSERT INTO students(name,furigana,nickName,email,area,age,gender,remark,is_deleted)" +
             " VALUES (#{name},#{furigana},#{nickName},#{email},#{area},#{age},#{gender},#{remark},false)")
     @Options(useGeneratedKeys = true, keyProperty = "id")
@@ -42,4 +42,11 @@ public interface StudentRepository {
     @Update("UPDATE  students_courses SET course_name = #{courseName}  WHERE id = #{id} ")
     void updateStudentCourse(StudentCourses studentCourses);
 
+    //受講生情報削除処理
+    @Delete("DELETE FROM students WHERE id = #{id}")
+    void deleteStudent(Student student);
+
+
+    @Delete("DELETE FROM students_courses WHERE id = #{id} ")
+    void deleteStudentCourse(StudentCourses studentCourses);
 }

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -3,7 +3,7 @@ package raisetech.StudentManagement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import raisetech.StudentManagement.Repository.StudentRepository;
+import raisetech.StudentManagement.repository.StudentRepository;
 
 
 @SpringBootApplication

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -86,5 +86,26 @@ public class StudentController {
         return "redirect:/studentList";
     }
 
+    //削除処理
+    @GetMapping("/students/{id}")
+    public String getStudents (@PathVariable String id, Model model) {
+        StudentDetail studentDetail = service.searchStudent(id);
+        model.addAttribute("studentDetail", studentDetail);
+        return "deleteStudent";
+    }
 
-}
+
+    @PostMapping("/deleteStudent")
+    public String deleteStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+        if (result.hasErrors()) {
+            return "deleteStudent";
+        }
+        service.deleteStudent(studentDetail);
+        return "redirect:/studentList";
+    }
+
+    }
+
+
+
+

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -1,4 +1,4 @@
-package raisetech.StudentManagement.Repository;
+package raisetech.StudentManagement.repository;
 //Model
 
 import org.apache.ibatis.annotations.*;
@@ -48,5 +48,5 @@ public interface StudentRepository {
 
 
     @Delete("DELETE FROM students_courses WHERE id = #{id} ")
-    void deleteStudentCourse(StudentCourses studentCourses);
+    void deleteStudentCourse(StudentCourses studentCourse);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -4,7 +4,7 @@ package raisetech.StudentManagement.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import raisetech.StudentManagement.Repository.StudentRepository;
+import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourses;
 import raisetech.StudentManagement.domain.StudentDetail;

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -22,7 +22,9 @@ public class StudentService {
     }
 
     public StudentDetail searchStudent(String id) {
+        //受講生情報(id一個)
         Student student = repository.searchStudent(id);
+        //コース情報(受講生情報に紐づくid)
         List<StudentCourses> studentsCourses = repository.searchStudentCourse(student.getId());
         StudentDetail studentDetail = new StudentDetail();
         studentDetail.setStudent(student);
@@ -31,12 +33,12 @@ public class StudentService {
     }
 
     public List<Student> searchStudentList() {
-        return repository.studentListSearch();
+        return repository.searchStudentList();
     }
 
 
     public List<StudentCourses> searchStudentCourseList() {
-        return repository.studentCourseListSearch();
+        return repository.searchStudentCourseList();
     }
 
     //StudentServiceで登録処理
@@ -62,5 +64,14 @@ public class StudentService {
         }
     }
 
+    //削除処理
+    @Transactional
+    public void deleteStudent(StudentDetail studentDetail) {
+        repository.deleteStudent(studentDetail.getStudent());
+        //コース情報登録
+        for (StudentCourses studentCourse : studentDetail.getStudentCourses()) {
+            repository.deleteStudentCourse(studentCourse);
+        }
+    }
 
 }

--- a/src/main/resources/templates/deleteStudent.html
+++ b/src/main/resources/templates/deleteStudent.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.w3.org/1999/xhtml">
+<head>
+  <title>受講生削除</title>
+</head>
+<body>
+<h1>受講生削除</h1>
+<form th:action="@{/deleteStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="id">ID:</label>
+    <input type="text" id="id" th:field="*{student.id}" required/>
+  </div>
+  <div>
+    <label for="name">名前:</label>
+    <input type="text" id="name" th:field="*{student.name}" required/>
+  </div>
+  <div>
+    <label for="furigana">フリガナ:</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickName">ニックネーム:</label>
+    <input type="text" id="nickName" th:field="*{student.nickName}" required/>
+  </div>
+  <div>
+    <label for="email">メール:</label>
+    <input type="text" id="email" th:field="*{student.email}" required/>
+  </div>
+  <div>
+    <label for="area">エリア:</label>
+    <input type="text" id="area" th:field="*{student.area}" required/>
+  </div>
+  <div>
+    <label for="age">年齢:</label>
+    <input type="text" id="age" th:field="*{student.age}"/>
+  </div>
+  <div>
+    <label for="gender">性別:</label>
+    <input type="text" id="gender" th:field="*{student.gender}"/>
+  </div>
+  <div>
+    <label for="remark">備考:</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+  <div th:each="course, stat : *{studentCourses}">
+
+    <label for="id"
+           th:for="studentCourse.__${stat.index}__.id">受講コースID:</label>
+    <input type="text" id="id"
+           th:id="studentCourse.__${stat.index}__.id"
+           th:field="*{studentCourses[__${stat.index}__].id}"/><label for="courseName"
+                                                                      th:for="studentCourse.__${stat.index}__.courseName">受講コース名:</label>
+    <input type="text" id="courseName"
+           th:id="studentCourse.__${stat.index}__.courseName"
+           th:field="*{studentCourses[__${stat.index}__].courseName}"/>
+  </div>
+  <div>
+    <button type="submit">削除</button>
+  </div>
+
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -26,7 +26,10 @@
             <a href="/studentList" th:href="@{student/{id}(id=${studentDetail.student.id})}"
                th:text="${studentDetail.student.name}">山田太朗</a>
         </td>
-        <td th:text="${studentDetail.student.furigana}">ヤマダタロウ</td>
+        <td>
+           <a href="/studentList" th:href="@{students/{id}(id=${studentDetail.student.id})}"
+              th:text="${studentDetail.student.furigana}">ヤマダタロウ</a>
+        </td>
         <td th:text="${studentDetail.student.nickName}">タロー</td>
         <td th:text="${studentDetail.student.email}">taro@example.com</td>
         <td th:text="${studentDetail.student.area}">東京</td>


### PR DESCRIPTION
### やったこと

1. 課題である受講情報削除処理を実装しました。
2. deleteStudent.htmlを追加

実行結果
<img width="821" alt="kadai30-1" src="https://github.com/user-attachments/assets/f6317a18-eb13-4552-8395-9d3300b41111" />
<img width="527" alt="kadai30-2" src="https://github.com/user-attachments/assets/10f9ff8a-9a96-4760-8ff9-af6693e147f6" />
<img width="866" alt="kadai30-3" src="https://github.com/user-attachments/assets/e6b59615-e776-4865-a99b-292e196b1fa9" />

### みて欲しいこと

- [ ] 動作確認
- [ ] 改善点：
本来の想定である受講生更新処理（updateStudent.html）のところにチェックボックスで削除ボタンを押して更新したらstudentListから指定された項目が消えるというものを作りたかったです。
ただ、htmlのところで書き方が分かりませんでした。
更新と同じ形にすればできるのでと思って、今回は受講生一覧のフリガナのところに削除処理を作りました笑　
とりあえず削除の流れはできたので提出します。

どのように作れば元々想定したものをできるか調べておりますが、未だわかってないです。

